### PR TITLE
add await to setBalance on CCIPLocalSimulatorFork.js

### DIFF
--- a/scripts/CCIPLocalSimulatorFork.js
+++ b/scripts/CCIPLocalSimulatorFork.js
@@ -108,7 +108,7 @@ async function routeMessage(routerAddress, evm2EvmMessage) {
             const evm2EvmOffRamp = new ethers.Contract(offRamp.offRamp, EVM2EVMOffRampAbi);
 
             const self = await ethers.getImpersonatedSigner(offRamp.offRamp);
-            setBalance(self.address, BigInt(100) ** BigInt(18));
+            await setBalance(self.address, BigInt(100) ** BigInt(18));
 
             const offchainTokenData = new Array(evm2EvmMessage.tokenAmounts.length).fill("0x");
 


### PR DESCRIPTION
I added "await" to  the `setBalance` call since it sometimes fails executeSingleMessage due to insufficient balance error.