### PR TITLE
Added SPDX license identifier to the src/shared/WETH9.sol file and added `--no-commit` flag to the forge install command in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install the package by running:
 #### Foundry (git)
 
 ```
-forge install smartcontractkit/chainlink-local
+forge install smartcontractkit/chainlink-local --no-commit
 ```
 
 and then set remappings to: `@chainlink/local/=lib/chainlink-local/` in either `remappings.txt` or `foundry.toml` file

--- a/src/shared/WETH9.sol
+++ b/src/shared/WETH9.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+
 // Submitted for verification at Etherscan.io on 2017-12-12
 
 // Copyright (C) 2015, 2016, 2017 Dapphub
@@ -63,16 +65,10 @@ contract WETH9 {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(
-        address src,
-        address dst,
-        uint256 wad
-    ) public returns (bool) {
+    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
         require(balanceOf[src] >= wad);
 
-        if (
-            src != msg.sender && allowance[src][msg.sender] != type(uint128).max
-        ) {
+        if (src != msg.sender && allowance[src][msg.sender] != type(uint128).max) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }


### PR DESCRIPTION
1. Added **SPDX license identifier** to the `src/shared/WETH9.sol` file to silence this warning:

   > **Warning:** SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
   > --> @chainlink/local/src/shared/WETH9.sol

   

2. Added `--no-commit` flag to the forge install command in the `README.md` file, so as to avoid this error while executing the command:

     > Error: 
     > The target directory is a part of or on its own an already initialized git repository,
     > and it requires clean working and staging areas, including no untracked files.
     > 
     > Check the current git repository's status with `git status`.
     > Then, you can track files with `git add ...` and then commit them with `git commit`,
     > ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.


