### PR TITLE
Support EVMExtraArgsV2 and OZ's AccessControl in CCIPLocalSimulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 30 November 2024
+
+### Dependencies
+
+| Package                   | Version      |
+| ------------------------- | ------------ |
+| @chainlink/contracts-ccip | 1.5.1-beta.0 |
+| @chainlink/contracts      | 1.1.1        |
+
+- [x] Chainlink CCIP
+- [x] Chainlink CCIP v1.5
+- [x] Chainlink Data Feeds
+- [ ] Chainlink Automation
+- [ ] Chainlink VRF 2
+- [ ] Chainlink VRF 2.5
+
+### Added
+
+- Added `supportNewTokenViaAccessControlDefaultAdmin` function to
+  `CCIPLocalSimulator.sol`
+- Bumped `@chainlink/contracts-ccip` to `1.5.1-beta.0` to reflect new changes in
+  the CCIP `TokenPool.sol` smart contract (check
+  [CCIPv1_5BurnMintPoolFork.t.sol](./test/e2e/ccip/CCIPv1_5ForkBurnMintPoolFork.t.sol)
+  and
+  [CCIPv1_5LockReleasePoolFork.t.sol](./test/e2e/ccip/CCIPv1_5ForkLockReleasePoolFork.t.sol)
+  tests) and to support `EVMExtraArgsV2` in `MockCCIPRouter.sol`
+
 ## [0.2.2] - 15 October 2024
 
 ### Dependencies
@@ -271,3 +298,4 @@ and this project adheres to
 [0.2.2-beta.1]:
   https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.2-beta.1
 [0.2.2]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.2
+[0.2.3]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.3

--- a/api_reference/solidity/ccip/CCIPLocalSimulator.mdx
+++ b/api_reference/solidity/ccip/CCIPLocalSimulator.mdx
@@ -70,6 +70,12 @@ The list of supported token addresses
 error CCIPLocalSimulator__MsgSenderIsNotTokenOwner()
 ```
 
+### CCIPLocalSimulator\_\_RequiredRoleNotFound
+
+```solidity
+error CCIPLocalSimulator__RequiredRoleNotFound(address account, bytes32 role, address token)
+```
+
 ### constructor
 
 ```solidity
@@ -103,6 +109,23 @@ function supportNewTokenViaGetCCIPAdmin(address tokenAddress) external
 Allows user to support any new token, besides CCIP BnM and CCIP LnM, for
 cross-chain transfers. Reverts if token does not implement getCCIPAdmin()
 function. Reverts if the caller is not the token CCIPAdmin.
+
+#### Parameters
+
+| Name         | Type    | Description                                                        |
+| ------------ | ------- | ------------------------------------------------------------------ |
+| tokenAddress | address | - The address of the token to add to the list of supported tokens. |
+
+### supportNewTokenViaAccessControlDefaultAdmin
+
+```solidity
+function supportNewTokenViaAccessControlDefaultAdmin(address tokenAddress) external
+```
+
+Allows user to support any new token, besides CCIP BnM and CCIP LnM, for
+cross-chain transfers. The caller must have the DEFAULT_ADMIN_ROLE as defined by
+the contract itself. Reverts if the caller is not the admin of the token using
+OZ's AccessControl DEFAULT_ADMIN_ROLE.
 
 #### Parameters
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@chainlink/contracts": "^1.1.1",
-        "@chainlink/contracts-ccip": "^1.5.0"
+        "@chainlink/contracts-ccip": "^1.5.1-beta.0"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-foundry": "^1.1.1",
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@chainlink/contracts-ccip": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts-ccip/-/contracts-ccip-1.5.0.tgz",
-      "integrity": "sha512-pz6vhAY6ey5vLjU6mUv7rapRIKXWS2kEhd+J4axdeQhyClfyl+HyzqBTL+Jd/tbekhrfEn2YbkhIZXlovvUk7w==",
+      "version": "1.5.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts-ccip/-/contracts-ccip-1.5.1-beta.0.tgz",
+      "integrity": "sha512-mlOuqV4YUY3mTleSchsJq4yqeTqX1qU68WPu4amdzCdj28P5L2vt1GZv56hC8AJHrk4DGhe5FM8sJScp1i01Pw==",
       "dependencies": {
         "@arbitrum/nitro-contracts": "1.1.1",
         "@arbitrum/token-bridge-contracts": "1.1.2",
@@ -170,6 +170,7 @@
         "@openzeppelin/contracts": "4.9.3",
         "@openzeppelin/contracts-upgradeable": "4.9.3",
         "@scroll-tech/contracts": "0.1.0",
+        "@zksync/contracts": "git+https://github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
         "semver": "^7.6.3"
       },
       "engines": {
@@ -4080,6 +4081,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
+    "node_modules/@zksync/contracts": {
+      "name": "era-contracts",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
+      "integrity": "sha512-F+mqGoqlXzBgGVeNDuzZOou4UvGoJC0aTLWLwMTKvKo0umUcR+Wocl1PRK9d+iavF1oAUgd5Ljpg+aKn8AwXQw==",
+      "workspaces": {
+        "packages": [
+          "l1-contracts",
+          "l2-contracts",
+          "system-contracts",
+          "gas-bound-caller"
+        ],
+        "nohoist": [
+          "**/@openzeppelin/**"
+        ]
+      }
     },
     "node_modules/abbrev": {
       "version": "1.0.9",
@@ -13110,9 +13128,9 @@
       }
     },
     "@chainlink/contracts-ccip": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts-ccip/-/contracts-ccip-1.5.0.tgz",
-      "integrity": "sha512-pz6vhAY6ey5vLjU6mUv7rapRIKXWS2kEhd+J4axdeQhyClfyl+HyzqBTL+Jd/tbekhrfEn2YbkhIZXlovvUk7w==",
+      "version": "1.5.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts-ccip/-/contracts-ccip-1.5.1-beta.0.tgz",
+      "integrity": "sha512-mlOuqV4YUY3mTleSchsJq4yqeTqX1qU68WPu4amdzCdj28P5L2vt1GZv56hC8AJHrk4DGhe5FM8sJScp1i01Pw==",
       "requires": {
         "@arbitrum/nitro-contracts": "1.1.1",
         "@arbitrum/token-bridge-contracts": "1.1.2",
@@ -13123,6 +13141,7 @@
         "@openzeppelin/contracts": "4.9.3",
         "@openzeppelin/contracts-upgradeable": "4.9.3",
         "@scroll-tech/contracts": "0.1.0",
+        "@zksync/contracts": "git+https://github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
         "semver": "^7.6.3"
       },
       "dependencies": {
@@ -15995,6 +16014,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
+    "@zksync/contracts": {
+      "version": "git+ssh://git@github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9",
+      "integrity": "sha512-F+mqGoqlXzBgGVeNDuzZOou4UvGoJC0aTLWLwMTKvKo0umUcR+Wocl1PRK9d+iavF1oAUgd5Ljpg+aKn8AwXQw==",
+      "from": "@zksync/contracts@git+https://github.com/matter-labs/era-contracts.git#446d391d34bdb48255d5f8fef8a8248925fc98b9"
     },
     "abbrev": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^1.1.1",
-    "@chainlink/contracts-ccip": "^1.5.0"
+    "@chainlink/contracts-ccip": "^1.5.1-beta.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@chainlink/local",
   "description": "Chainlink Local Simulator",
   "license": "MIT",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "files": [
     "src/**/*.sol",
     "!src/test/**/*",

--- a/test/e2e/ccip/CCIPv1_5ForkBurnMintPoolFork.t.sol
+++ b/test/e2e/ccip/CCIPv1_5ForkBurnMintPoolFork.t.sol
@@ -101,10 +101,12 @@ contract CCIPv1_5BurnMintPoolFork is Test {
         Register.NetworkDetails memory ethSepoliaNetworkDetails =
             ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
         address[] memory allowlist = new address[](0);
+        uint8 localTokenDecimals = 18;
 
         vm.startPrank(alice);
         BurnMintTokenPool burnMintTokenPoolEthSepolia = new BurnMintTokenPool(
             IBurnMintERC20(address(mockERC20TokenEthSepolia)),
+            localTokenDecimals,
             allowlist,
             ethSepoliaNetworkDetails.rmnProxyAddress,
             ethSepoliaNetworkDetails.routerAddress
@@ -118,6 +120,7 @@ contract CCIPv1_5BurnMintPoolFork is Test {
         vm.startPrank(alice);
         BurnMintTokenPool burnMintTokenPoolBaseSepolia = new BurnMintTokenPool(
             IBurnMintERC20(address(mockERC20TokenBaseSepolia)),
+            localTokenDecimals,
             allowlist,
             baseSepoliaNetworkDetails.rmnProxyAddress,
             baseSepoliaNetworkDetails.routerAddress
@@ -203,15 +206,17 @@ contract CCIPv1_5BurnMintPoolFork is Test {
 
         vm.startPrank(alice);
         TokenPool.ChainUpdate[] memory chains = new TokenPool.ChainUpdate[](1);
+        bytes[] memory remotePoolAddressesEthSepolia = new bytes[](1);
+        remotePoolAddressesEthSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
         chains[0] = TokenPool.ChainUpdate({
             remoteChainSelector: baseSepoliaNetworkDetails.chainSelector,
-            allowed: true,
-            remotePoolAddress: abi.encode(address(burnMintTokenPoolBaseSepolia)),
+            remotePoolAddresses: remotePoolAddressesEthSepolia,
             remoteTokenAddress: abi.encode(address(mockERC20TokenBaseSepolia)),
             outboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: 100_000, rate: 167}),
             inboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: 100_000, rate: 167})
         });
-        burnMintTokenPoolEthSepolia.applyChainUpdates(chains);
+        uint64[] memory remoteChainSelectorsToRemove = new uint64[](0);
+        burnMintTokenPoolEthSepolia.applyChainUpdates(remoteChainSelectorsToRemove, chains);
         vm.stopPrank();
 
         // Step 14) Configure Token Pool on Base Sepolia
@@ -219,15 +224,16 @@ contract CCIPv1_5BurnMintPoolFork is Test {
 
         vm.startPrank(alice);
         chains = new TokenPool.ChainUpdate[](1);
+        bytes[] memory remotePoolAddressesBaseSepolia = new bytes[](1);
+        remotePoolAddressesBaseSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
         chains[0] = TokenPool.ChainUpdate({
             remoteChainSelector: ethSepoliaNetworkDetails.chainSelector,
-            allowed: true,
-            remotePoolAddress: abi.encode(address(burnMintTokenPoolEthSepolia)),
+            remotePoolAddresses: remotePoolAddressesBaseSepolia,
             remoteTokenAddress: abi.encode(address(mockERC20TokenEthSepolia)),
             outboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: 100_000, rate: 167}),
             inboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: 100_000, rate: 167})
         });
-        burnMintTokenPoolBaseSepolia.applyChainUpdates(chains);
+        burnMintTokenPoolBaseSepolia.applyChainUpdates(remoteChainSelectorsToRemove, chains);
         vm.stopPrank();
 
         // Step 15) Mint tokens on Ethereum Sepolia and transfer them to Base Sepolia

--- a/test/e2e/ccip/CCIPv1_5ForkBurnMintPoolFork.t.sol
+++ b/test/e2e/ccip/CCIPv1_5ForkBurnMintPoolFork.t.sol
@@ -63,7 +63,10 @@ contract CCIPv1_5BurnMintPoolFork is Test {
     CCIPLocalSimulatorFork public ccipLocalSimulatorFork;
     MockERC20BurnAndMintToken public mockERC20TokenEthSepolia;
     MockERC20BurnAndMintToken public mockERC20TokenBaseSepolia;
+    BurnMintTokenPool public burnMintTokenPoolEthSepolia;
+    BurnMintTokenPool public burnMintTokenPoolBaseSepolia;
 
+    Register.NetworkDetails ethSepoliaNetworkDetails;
     Register.NetworkDetails baseSepoliaNetworkDetails;
 
     uint256 ethSepoliaFork;
@@ -98,13 +101,12 @@ contract CCIPv1_5BurnMintPoolFork is Test {
     function test_forkSupportNewCCIPToken() public {
         // Step 3) Deploy BurnMintTokenPool on Ethereum Sepolia
         vm.selectFork(ethSepoliaFork);
-        Register.NetworkDetails memory ethSepoliaNetworkDetails =
-            ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
+        ethSepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
         address[] memory allowlist = new address[](0);
         uint8 localTokenDecimals = 18;
 
         vm.startPrank(alice);
-        BurnMintTokenPool burnMintTokenPoolEthSepolia = new BurnMintTokenPool(
+        burnMintTokenPoolEthSepolia = new BurnMintTokenPool(
             IBurnMintERC20(address(mockERC20TokenEthSepolia)),
             localTokenDecimals,
             allowlist,
@@ -118,7 +120,7 @@ contract CCIPv1_5BurnMintPoolFork is Test {
         baseSepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
 
         vm.startPrank(alice);
-        BurnMintTokenPool burnMintTokenPoolBaseSepolia = new BurnMintTokenPool(
+        burnMintTokenPoolBaseSepolia = new BurnMintTokenPool(
             IBurnMintERC20(address(mockERC20TokenBaseSepolia)),
             localTokenDecimals,
             allowlist,

--- a/test/e2e/ccip/CCIPv1_5LockReleasePoolFork.t.sol
+++ b/test/e2e/ccip/CCIPv1_5LockReleasePoolFork.t.sol
@@ -65,10 +65,12 @@ contract CCIPv1_5LockReleasePoolFork is Test {
         Register.NetworkDetails memory ethSepoliaNetworkDetails =
             ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
         address[] memory allowlist = new address[](0);
+        uint8 localTokenDecimals = 18;
 
         vm.startPrank(alice);
         LockReleaseTokenPool lockReleaseTokenPoolEthSepolia = new LockReleaseTokenPool(
             IERC20(address(mockERC20TokenEthSepolia)),
+            localTokenDecimals,
             allowlist,
             ethSepoliaNetworkDetails.rmnProxyAddress,
             true, // acceptLiquidity
@@ -84,6 +86,7 @@ contract CCIPv1_5LockReleasePoolFork is Test {
         vm.startPrank(alice);
         LockReleaseTokenPool lockReleaseTokenPoolBaseSepolia = new LockReleaseTokenPool(
             IERC20(address(mockERC20TokenBaseSepolia)),
+            localTokenDecimals,
             allowlist,
             baseSepoliaNetworkDetails.rmnProxyAddress,
             true, // acceptLiquidity
@@ -174,15 +177,17 @@ contract CCIPv1_5LockReleasePoolFork is Test {
 
         vm.startPrank(alice);
         TokenPool.ChainUpdate[] memory chains = new TokenPool.ChainUpdate[](1);
+        bytes[] memory remotePoolAddressesEthSepolia = new bytes[](1);
+        remotePoolAddressesEthSepolia[0] = abi.encode(address(lockReleaseTokenPoolBaseSepolia));
         chains[0] = TokenPool.ChainUpdate({
             remoteChainSelector: baseSepoliaNetworkDetails.chainSelector,
-            allowed: true,
-            remotePoolAddress: abi.encode(address(lockReleaseTokenPoolBaseSepolia)),
+            remotePoolAddresses: remotePoolAddressesEthSepolia,
             remoteTokenAddress: abi.encode(address(mockERC20TokenBaseSepolia)),
             outboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: liquidityAmount, rate: 167}),
             inboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: liquidityAmount, rate: 167})
         });
-        lockReleaseTokenPoolEthSepolia.applyChainUpdates(chains);
+        uint64[] memory remoteChainSelectorsToRemove = new uint64[](0);
+        lockReleaseTokenPoolEthSepolia.applyChainUpdates(remoteChainSelectorsToRemove, chains);
         vm.stopPrank();
 
         // Step 14) Configure Token Pool on Base Sepolia
@@ -190,15 +195,16 @@ contract CCIPv1_5LockReleasePoolFork is Test {
 
         vm.startPrank(alice);
         chains = new TokenPool.ChainUpdate[](1);
+        bytes[] memory remotePoolAddressesBaseSepolia = new bytes[](1);
+        remotePoolAddressesBaseSepolia[0] = abi.encode(address(lockReleaseTokenPoolEthSepolia));
         chains[0] = TokenPool.ChainUpdate({
             remoteChainSelector: ethSepoliaNetworkDetails.chainSelector,
-            allowed: true,
-            remotePoolAddress: abi.encode(address(lockReleaseTokenPoolEthSepolia)),
+            remotePoolAddresses: remotePoolAddressesBaseSepolia,
             remoteTokenAddress: abi.encode(address(mockERC20TokenEthSepolia)),
             outboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: liquidityAmount, rate: 167}),
             inboundRateLimiterConfig: RateLimiter.Config({isEnabled: true, capacity: liquidityAmount, rate: 167})
         });
-        lockReleaseTokenPoolBaseSepolia.applyChainUpdates(chains);
+        lockReleaseTokenPoolBaseSepolia.applyChainUpdates(remoteChainSelectorsToRemove, chains);
         vm.stopPrank();
 
         // Step 15) Transfer tokens from Ethereum Sepolia to Base Sepolia

--- a/test/e2e/ccip/CCIPv1_5LockReleasePoolFork.t.sol
+++ b/test/e2e/ccip/CCIPv1_5LockReleasePoolFork.t.sol
@@ -29,6 +29,11 @@ contract CCIPv1_5LockReleasePoolFork is Test {
     CCIPLocalSimulatorFork public ccipLocalSimulatorFork;
     MockERC20TokenOwner public mockERC20TokenEthSepolia;
     MockERC20TokenOwner public mockERC20TokenBaseSepolia;
+    LockReleaseTokenPool public lockReleaseTokenPoolEthSepolia;
+    LockReleaseTokenPool public lockReleaseTokenPoolBaseSepolia;
+
+    Register.NetworkDetails ethSepoliaNetworkDetails;
+    Register.NetworkDetails baseSepoliaNetworkDetails;
 
     uint256 ethSepoliaFork;
     uint256 baseSepoliaFork;
@@ -62,13 +67,12 @@ contract CCIPv1_5LockReleasePoolFork is Test {
     function test_forkSupportNewCCIPToken() public {
         // Step 3) Deploy LockReleaseTokenPool on Ethereum Sepolia
         vm.selectFork(ethSepoliaFork);
-        Register.NetworkDetails memory ethSepoliaNetworkDetails =
-            ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
+        ethSepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
         address[] memory allowlist = new address[](0);
         uint8 localTokenDecimals = 18;
 
         vm.startPrank(alice);
-        LockReleaseTokenPool lockReleaseTokenPoolEthSepolia = new LockReleaseTokenPool(
+        lockReleaseTokenPoolEthSepolia = new LockReleaseTokenPool(
             IERC20(address(mockERC20TokenEthSepolia)),
             localTokenDecimals,
             allowlist,
@@ -80,11 +84,10 @@ contract CCIPv1_5LockReleasePoolFork is Test {
 
         // Step 4) Deploy LockReleaseTokenPool on Base Sepolia
         vm.selectFork(baseSepoliaFork);
-        Register.NetworkDetails memory baseSepoliaNetworkDetails =
-            ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
+        baseSepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
 
         vm.startPrank(alice);
-        LockReleaseTokenPool lockReleaseTokenPoolBaseSepolia = new LockReleaseTokenPool(
+        lockReleaseTokenPoolBaseSepolia = new LockReleaseTokenPool(
             IERC20(address(mockERC20TokenBaseSepolia)),
             localTokenDecimals,
             allowlist,

--- a/test/unit/ccip/CCIPLocalSimulatorUnit.t.sol
+++ b/test/unit/ccip/CCIPLocalSimulatorUnit.t.sol
@@ -2,11 +2,14 @@
 pragma solidity ^0.8.0;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {CCIPLocalSimulator} from "@chainlink/local/src/ccip/CCIPLocalSimulator.sol";
+import {CCIPLocalSimulator, IRouterClient} from "@chainlink/local/src/ccip/CCIPLocalSimulator.sol";
 
+import {Client} from "@chainlink/contracts-ccip/src/v0.8/ccip/libraries/Client.sol";
 import {ERC20} from
     "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v5.0.2/contracts/token/ERC20/ERC20.sol";
 import {OwnerIsCreator} from "@chainlink/contracts-ccip/src/v0.8/shared/access/OwnerIsCreator.sol";
+import {AccessControl} from
+    "@chainlink/contracts-ccip/src/v0.8/vendor/openzeppelin-solidity/v5.0.2/contracts/access/AccessControl.sol";
 
 contract MockERC20TokenOwner is ERC20, OwnerIsCreator {
     constructor() ERC20("MockERC20Token", "MTK") {}
@@ -33,11 +36,26 @@ contract MockERC20TokenGetCCIPAdmin is ERC20 {
     }
 }
 
+contract MockERC20AccessControl is ERC20, AccessControl {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    constructor() ERC20("MockERC20Token", "MTK") {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    function mint(address account, uint256 amount) external {
+        require(hasRole(MINTER_ROLE, msg.sender));
+        _mint(account, amount);
+    }
+}
+
 contract CCIPLocalSimulatorUnitTest is Test {
     CCIPLocalSimulator public ccipLocalSimulator;
+    IRouterClient public router;
 
     MockERC20TokenOwner public mockERC20TokenOwner;
     MockERC20TokenGetCCIPAdmin public mockERC20TokenGetCCIPAdmin;
+    MockERC20AccessControl public mockERC20AccessControl;
 
     address alice;
     address bob;
@@ -46,8 +64,9 @@ contract CCIPLocalSimulatorUnitTest is Test {
     function setUp() public {
         ccipLocalSimulator = new CCIPLocalSimulator();
 
-        (uint64 chainSelector_,,,,,,) = ccipLocalSimulator.configuration();
+        (uint64 chainSelector_, IRouterClient sourceRouter,,,,,) = ccipLocalSimulator.configuration();
         chainSelector = chainSelector_;
+        router = sourceRouter;
 
         alice = makeAddr("alice");
         bob = makeAddr("bob");
@@ -55,6 +74,7 @@ contract CCIPLocalSimulatorUnitTest is Test {
         vm.startPrank(alice);
         mockERC20TokenOwner = new MockERC20TokenOwner();
         mockERC20TokenGetCCIPAdmin = new MockERC20TokenGetCCIPAdmin();
+        mockERC20AccessControl = new MockERC20AccessControl();
         vm.stopPrank();
 
         assertEq(mockERC20TokenOwner.owner(), alice);
@@ -100,6 +120,58 @@ contract CCIPLocalSimulatorUnitTest is Test {
             abi.encodeWithSelector(CCIPLocalSimulator.CCIPLocalSimulator__MsgSenderIsNotTokenOwner.selector)
         );
         ccipLocalSimulator.supportNewTokenViaGetCCIPAdmin(address(mockERC20TokenGetCCIPAdmin));
+        vm.stopPrank();
+    }
+
+    function test_shouldSupportNewTokenIfCalledByAccessControlDefaultAdmin() public {
+        address[] memory supportedTokensBefore = ccipLocalSimulator.getSupportedTokens(chainSelector);
+
+        vm.startPrank(alice);
+        ccipLocalSimulator.supportNewTokenViaAccessControlDefaultAdmin(address(mockERC20AccessControl));
+        vm.stopPrank();
+
+        address[] memory supportedTokensAfter = ccipLocalSimulator.getSupportedTokens(chainSelector);
+        assertEq(supportedTokensAfter.length, supportedTokensBefore.length + 1);
+        assertEq(supportedTokensAfter[supportedTokensAfter.length - 1], address(mockERC20AccessControl));
+    }
+
+    function test_shouldRevertIfSupportNewTokenIsNotCalledByAccessControlDefaultAdmin() public {
+        vm.startPrank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CCIPLocalSimulator.CCIPLocalSimulator__RequiredRoleNotFound.selector,
+                bob,
+                mockERC20AccessControl.DEFAULT_ADMIN_ROLE(),
+                address(mockERC20AccessControl)
+            )
+        );
+        ccipLocalSimulator.supportNewTokenViaAccessControlDefaultAdmin(address(mockERC20AccessControl));
+        vm.stopPrank();
+    }
+
+    function test_shouldSendCCIPMessageWithEvmExtraArgsV1() public {
+        vm.startPrank(alice);
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(bob),
+            data: "",
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: 500_000})),
+            feeToken: address(0)
+        });
+        router.ccipSend(chainSelector, message);
+        vm.stopPrank();
+    }
+
+    function test_shouldSendCCIPMessageWithEvmExtraArgsV2() public {
+        vm.startPrank(alice);
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(bob),
+            data: "",
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: Client._argsToBytes(Client.EVMExtraArgsV2({gasLimit: 500_000, allowOutOfOrderExecution: true})),
+            feeToken: address(0)
+        });
+        router.ccipSend(chainSelector, message);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
This PR:
- Added `supportNewTokenViaAccessControlDefaultAdmin` function to `CCIPLocalSimulator.sol`
- Bumped `@chainlink/contracts-ccip` to `1.5.1-beta.0` to reflect new changes in the CCIP `TokenPool.sol` smart contract (check [CCIPv1_5BurnMintPoolFork.t.sol](./test/e2e/ccip/CCIPv1_5ForkBurnMintPoolFork.t.sol) and [CCIPv1_5LockReleasePoolFork.t.sol](./test/e2e/ccip/CCIPv1_5ForkLockReleasePoolFork.t.sol) tests) and to support `EVMExtraArgsV2` in `MockCCIPRouter.sol` 