### PR TITLE
Add support for soldeer package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+
 .env
 .env.enc
 .DS_Store
@@ -6,6 +7,9 @@ node_modules
 # Foundry files
 cache_forge/
 out/
+soldeer.lock
+remappings.txt
+dependencies
 
 # Hardhat files
 /cache

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,3 +11,7 @@ remappings = [
     '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/',
     '@chainlink/local/src/=src/',
 ]
+
+[dependencies]
+"smartcontractkit-ccip" = { version = "2.17.0-ccip1.5.12"}
+"smartcontractkit-chainlink-brownie-contracts" = {version = "1.3.0"}


### PR DESCRIPTION
Added support for soldeer package manager. Users can now command `forge soldeer install` and download dependencies