### PR TITLE
feat(ci-cd-composite-action): debugging ci-cd with action

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,23 @@
+name: Node setup and Install Dependencies
+
+inputs:
+  npm-token:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "20.x"
+        registry-url: "https://registry.npmjs.org"
+        always-auth: true
+
+    - name: Setup npm authentication
+      run: echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token }}" > ~/.npmrc
+      shell: bash
+
+    - name: Install dependencies
+      run: npm ci
+      shell: bash

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -12,18 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Node, auth, and install deps
+        uses: ./.github/actions/install
         with:
-          node-version: "20.x"
-          registry-url: "https://registry.npmjs.org"
-          always-auth: true
-
-      - name: Setup npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_CHAINLINK_LOCAL }}" > ~/.npmrc
-
-      - name: Install dependencies
-        run: npm ci
+          npm-token: ${{ secrets.NPM_CHAINLINK_LOCAL }}
 
       - name: Publish
         run: npm publish --tag beta

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,18 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Node, auth, and install deps
+        uses: ./.github/actions/install
         with:
-          node-version: "20.x"
-          registry-url: "https://registry.npmjs.org"
-          always-auth: true
-
-      - name: Setup npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_CHAINLINK_LOCAL }}" > ~/.npmrc
-
-      - name: Install dependencies
-        run: npm ci
+          npm-token: ${{ secrets.NPM_CHAINLINK_LOCAL }}
 
       - name: Publish
         run: npm publish


### PR DESCRIPTION
### Feature: Use Composite Action for Node Setup and Dependency Installation

This PR introduces a reusable composite action (`.github/actions/install`) to standardize Node.js setup, npm authentication, and dependency installation across workflows. It accepts an `npm-token` input and uses `npm ci` for reliable installs.

Both `publish.yml` and `publish-beta-release.yml` now leverage this composite action, improving maintainability and ensuring consistent environment setup. The workflows continue to perform a `checkout` step separately before invoking the action, as required.
