### PR TITLE
CCIP Fork: Route multiple messages to multiple chains at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6-beta.0] - 10 September 2025
+
+### Dependencies
+
+| Package                   | Version |
+| ------------------------- | ------- |
+| @chainlink/contracts-ccip | 1.6.0   |
+| @chainlink/contracts      | 1.4.0   |
+
+### Services
+
+- [x] Chainlink CCIP v1.6
+
+### Changed
+
+- Refactored `CCIPLocalSimulatorFork.sol` to deliver more than one message to more than one chain in a same call
+
 ## [0.2.6-beta] - 11 June 2025
 
 ### Dependencies
@@ -505,3 +522,5 @@ and this project adheres to
 [0.2.5]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.5
 [0.2.6-beta]:
   https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.6-beta
+[0.2.6-beta.0]:
+  https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.6-beta.0

--- a/api_reference/javascript/CCIPLocalSimulatorFork.mdx
+++ b/api_reference/javascript/CCIPLocalSimulatorFork.mdx
@@ -25,6 +25,16 @@
     </p>
   </dd>
   <dt>
+    <a href="#getEvm2AnyRampMessage">getEvm2AnyRampMessage(receipt)</a> ⇒{' '}
+    <code>object</code> | <code>null</code>
+  </dt>
+  <dd>
+    <p>
+      Parses a transaction receipt to extract the sent message from
+      CCIPMessageSent
+    </p>
+  </dd>
+  <dt>
     <a href="#routeMessage">routeMessage(routerAddress, evm2EvmMessage)</a> ⇒{' '}
     <code>Promise.&lt;void&gt;</code>
   </dt>
@@ -77,6 +87,20 @@ does not contain `CCIPSendRequested` log
 | Param   | Type                | Description                                      |
 | ------- | ------------------- | ------------------------------------------------ |
 | receipt | <code>object</code> | The transaction receipt from the `ccipSend` call |
+
+<a name="getEvm2AnyRampMessage"></a>
+
+## getEvm2AnyRampMessage(receipt) ⇒ <code>object</code> \| <code>null</code>
+
+Parses a transaction receipt to extract the sent message from CCIPMessageSent
+
+**Kind**: global function  
+**Returns**: <code>object</code> \| <code>null</code> - Returns {
+destChainSelector, sequenceNumber, EVM2AnyRampMessage message } or null
+
+| Param   | Type                | Description                                |
+| ------- | ------------------- | ------------------------------------------ |
+| receipt | <code>object</code> | – The tx receipt from the on-ramp contract |
 
 <a name="routeMessage"></a>
 

--- a/api_reference/solidity/ccip/CCIPLocalSimulatorFork.mdx
+++ b/api_reference/solidity/ccip/CCIPLocalSimulatorFork.mdx
@@ -18,6 +18,21 @@ struct OffRamp {
 }
 ```
 
+### getOnRamp
+
+```solidity
+function getOnRamp(uint64 destChainSelector) external view returns (address)
+```
+
+Return the configured onramp for specific a destination chain. @param
+destChainSelector The destination chain Id to get the onRamp for.
+
+#### Return Values
+
+| Name | Type    | Description                |
+| ---- | ------- | -------------------------- |
+| [0]  | address | The address of the onRamp. |
+
 ### getOffRamps
 
 ```solidity
@@ -37,18 +52,48 @@ Gets the list of offRamps
 ### executeSingleMessage
 
 ```solidity
-function executeSingleMessage(struct Internal.EVM2EVMMessage message, bytes[] offchainTokenData, uint32[] tokenGasOverrides) external
+function executeSingleMessage(struct Internal.Any2EVMRampMessage message, bytes[] offchainTokenData, uint32[] tokenGasOverrides) external
 ```
 
 Executes a single CCIP message on the offRamp
 
 #### Parameters
 
-| Name              | Type                           | Description                       |
-| ----------------- | ------------------------------ | --------------------------------- |
-| message           | struct Internal.EVM2EVMMessage | - The CCIP message to be executed |
-| offchainTokenData | bytes[]                        | - Additional offchain token data  |
-| tokenGasOverrides | uint32[]                       |                                   |
+| Name              | Type                               | Description                       |
+| ----------------- | ---------------------------------- | --------------------------------- |
+| message           | struct Internal.Any2EVMRampMessage | - The CCIP message to be executed |
+| offchainTokenData | bytes[]                            | - Additional offchain token data  |
+| tokenGasOverrides | uint32[]                           |                                   |
+
+## InternalPreV1dot6
+
+### EVM2EVMMessage
+
+```solidity
+struct EVM2EVMMessage {
+  uint64 sourceChainSelector;
+  address sender;
+  address receiver;
+  uint64 sequenceNumber;
+  uint256 gasLimit;
+  bool strict;
+  uint64 nonce;
+  address feeToken;
+  uint256 feeTokenAmount;
+  bytes data;
+  struct Client.EVMTokenAmount[] tokenAmounts;
+  bytes[] sourceTokenData;
+  bytes32 messageId;
+}
+```
+
+## IEVM2EVMOffRampPreV1dot6Fork
+
+### executeSingleMessage
+
+```solidity
+function executeSingleMessage(struct InternalPreV1dot6.EVM2EVMMessage message, bytes[] offchainTokenData, uint32[] tokenGasOverrides) external
+```
 
 ## CCIPLocalSimulatorFork
 
@@ -57,16 +102,28 @@ Works with Foundry only
 ### CCIPSendRequested
 
 ```solidity
-event CCIPSendRequested(struct Internal.EVM2EVMMessage message)
+event CCIPSendRequested(struct InternalPreV1dot6.EVM2EVMMessage message)
 ```
 
-Event emitted when a CCIP send request is made
+Events emitted when a CCIP send request is made
 
-#### Parameters
+### CCIPMessageSent
 
-| Name    | Type                           | Description                         |
-| ------- | ------------------------------ | ----------------------------------- |
-| message | struct Internal.EVM2EVMMessage | - The EVM2EVM message that was sent |
+```solidity
+event CCIPMessageSent(uint64 destChainSelector, uint64 sequenceNumber, struct Internal.EVM2AnyRampMessage message)
+```
+
+### InvalidExtraArgsTag
+
+```solidity
+error InvalidExtraArgsTag()
+```
+
+### DEFAULT_GAS_LIMIT
+
+```solidity
+uint32 DEFAULT_GAS_LIMIT
+```
 
 ### i_register
 
@@ -107,15 +164,36 @@ function switchChainAndRouteMessage(uint256 forkId) external
 ```
 
 To be called after the sending of the cross-chain message (`ccipSend`). Goes
-through the list of past logs and looks for the `CCIPSendRequested` event.
-Switches to a destination network fork. Routes the sent cross-chain message on
-the destination network.
+through the list of past logs and looks for the `CCIPSendRequested` and
+`CCIPMessageSent` events. Switches to a destination network fork. Routes the
+sent cross-chain message on the destination network. If you sent more than one
+message, it will try to route all of them to `forkId`.
 
 #### Parameters
 
 | Name   | Type    | Description                                                                                                    |
 | ------ | ------- | -------------------------------------------------------------------------------------------------------------- |
 | forkId | uint256 | - The ID of the destination network fork. This is the returned value of `createFork()` or `createSelectFork()` |
+
+### switchChainAndRouteMessage
+
+```solidity
+function switchChainAndRouteMessage(uint256[] forkIds) external
+```
+
+To be called after the sending of the cross-chain message (`ccipSend`). Override
+variant of the `switchChainAndRouteMessage(uint256 forkId)` function in case of
+multiple destination forks. Goes through the list of past logs and looks for the
+`CCIPSendRequested` and `CCIPMessageSent` events. Loops through provided
+`forkIds` and tries to route the message to correct destination. If you haven't
+provide correct `forkId`, the message will get lost. If you sent more than one
+message, it will try to route all of them to correct destinations.
+
+#### Parameters
+
+| Name    | Type      | Description                                                                                                         |
+| ------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
+| forkIds | uint256[] | - The IDs of the destination network forks. These are the returned values of `createFork()` or `createSelectFork()` |
 
 ### getNetworkDetails
 
@@ -176,3 +254,41 @@ transferred to provided destination address.
 | Name    | Type | Description                                                                   |
 | ------- | ---- | ----------------------------------------------------------------------------- |
 | success | bool | - Returns `true` if the transfer of tokens was successful, otherwise `false`. |
+
+### \_routeCapturedMessages
+
+```solidity
+function _routeCapturedMessages(uint256[] forkIds, uint256 sourceForkId, address sourceRouterAddress) internal
+```
+
+Internal function to route captured messages to their respective destination
+forks.
+
+#### Parameters
+
+| Name                | Type      | Description                                                                                                                        |
+| ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| forkIds             | uint256[] | - The IDs of the destination network forks. These are the returned values of `createFork()` or `createSelectFork()`, not chainIds. |
+| sourceForkId        | uint256   | - The ID of the source network fork. This is the returned value of `createFork()` or `createSelectFork()`, not chainId.            |
+| sourceRouterAddress | address   | - The address of the Router on the source chain.                                                                                   |
+
+### \_fromBytes
+
+```solidity
+function _fromBytes(bytes extraArgs) internal pure returns (struct Client.GenericExtraArgsV2)
+```
+
+Internal helper function to decode extraArgs bytes to GenericExtraArgsV2 struct.
+Supports decoding of both GenericExtraArgsV2 and EVMExtraArgsV1 structs.
+
+#### Parameters
+
+| Name      | Type  | Description                                   |
+| --------- | ----- | --------------------------------------------- |
+| extraArgs | bytes | - The bytes representing the extra arguments. |
+
+#### Return Values
+
+| Name | Type                             | Description                                               |
+| ---- | -------------------------------- | --------------------------------------------------------- |
+| [0]  | struct Client.GenericExtraArgsV2 | genericExtraArgs - The decoded GenericExtraArgsV2 struct. |

--- a/api_reference/solidity/shared/ITypeAndVersion.mdx
+++ b/api_reference/solidity/shared/ITypeAndVersion.mdx
@@ -1,0 +1,9 @@
+# Solidity API
+
+## ITypeAndVersion
+
+### typeAndVersion
+
+```solidity
+function typeAndVersion() external pure returns (string)
+```

--- a/api_reference/solidity/shared/index.mdx
+++ b/api_reference/solidity/shared/index.mdx
@@ -1,4 +1,5 @@
 # Shared API Reference
 
+- [ITypeAndVersion](ITypeAndVersion.mdx)
 - [LinkToken](LinkToken.mdx)
 - [WETH9](WETH9.mdx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/local",
-  "version": "0.2.5-beta.0",
+  "version": "0.2.6-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/local",
-      "version": "0.2.5-beta.0",
+      "version": "0.2.6-beta.0",
       "license": "MIT",
       "dependencies": {
         "@chainlink/contracts": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@chainlink/local",
   "description": "Chainlink Local Simulator",
   "license": "MIT",
-  "version": "0.2.6-beta",
+  "version": "0.2.6-beta.0",
   "files": [
     "src/**/*.sol",
     "!src/test/**/*",

--- a/src/ccip/CCIPLocalSimulatorFork.sol
+++ b/src/ccip/CCIPLocalSimulatorFork.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.19;
 
 import {Test, Vm, console2} from "forge-std/Test.sol";
 import {Register} from "./Register.sol";
-import {ITypeAndVersion} from "../shared/ITypeAndVersion.sol";
 import {Internal} from "@chainlink/contracts-ccip/contracts/libraries/Internal.sol";
 import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 import {IERC20} from
@@ -112,187 +111,38 @@ contract CCIPLocalSimulatorFork is Test {
     }
 
     /**
-     * @notice To be called after the sending of the cross-chain message (`ccipSend`). Goes through the list of past logs and looks for the `CCIPSendRequested` event. Switches to a destination network fork. Routes the sent cross-chain message on the destination network.
+     * @notice  To be called after the sending of the cross-chain message (`ccipSend`).
+     *          Goes through the list of past logs and looks for the `CCIPSendRequested` and `CCIPMessageSent` events.
+     *          Switches to a destination network fork. Routes the sent cross-chain message on the destination network.
+     *          If you sent more than one message, it will try to route all of them to `forkId`.
      *
      * @param forkId - The ID of the destination network fork. This is the returned value of `createFork()` or `createSelectFork()`
      */
     function switchChainAndRouteMessage(uint256 forkId) external {
-        uint256 currentForkId = vm.activeFork();
-        address routerAddress = i_register.getNetworkDetails(block.chainid).routerAddress;
-        vm.selectFork(forkId);
-        uint64 destinationChainSelector = i_register.getNetworkDetails(block.chainid).chainSelector;
-        vm.selectFork(currentForkId);
-        address onRampContract = IRouterFork(routerAddress).getOnRamp(destinationChainSelector);
-        bytes memory typeAndVersion = bytes(ITypeAndVersion(onRampContract).typeAndVersion());
-        bytes1 minorVersion = typeAndVersion[typeAndVersion.length - 3];
-        // 0x36 is ASCII for "6"
-        if (minorVersion >= 0x36) {
-            _routePostV1dot6Message(forkId);
-        } else {
-            _routePreV1dot6Message(forkId);
-        }
+        uint256 sourceForkId = vm.activeFork();
+        address sourceRouterAddress = i_register.getNetworkDetails(block.chainid).routerAddress;
+
+        uint256[] memory forkIds = new uint256[](1);
+        forkIds[0] = forkId;
+
+        _routeCapturedMessages(forkIds, sourceForkId, sourceRouterAddress);
     }
 
-    function _routePreV1dot6Message(uint256 forkId) internal {
-        uint256 currentForkId = vm.activeFork();
+    /**
+     * @notice  To be called after the sending of the cross-chain message (`ccipSend`).
+     *          Override variant of the `switchChainAndRouteMessage(uint256 forkId)` function in case of multiple destination forks.
+     *          Goes through the list of past logs and looks for the `CCIPSendRequested` and `CCIPMessageSent` events.
+     *          Loops through provided `forkIds` and tries to route the message to correct destination.
+     *          If you haven't provide correct `forkId`, the message will get lost.
+     *          If you sent more than one message, it will try to route all of them to correct destinations.
+     *
+     * @param forkIds - The IDs of the destination network forks. These are the returned values of `createFork()` or `createSelectFork()`
+     */
+    function switchChainAndRouteMessage(uint256[] memory forkIds) external {
+        uint256 sourceForkId = vm.activeFork();
+        address sourceRouterAddress = i_register.getNetworkDetails(block.chainid).routerAddress;
 
-        vm.selectFork(forkId);
-        assertEq(vm.activeFork(), forkId);
-        IRouterFork.OffRamp[] memory offRamps =
-            IRouterFork(i_register.getNetworkDetails(block.chainid).routerAddress).getOffRamps();
-        uint256 offRampsLength = offRamps.length;
-
-        vm.selectFork(currentForkId);
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 logsLength = entries.length;
-        for (uint256 i; i < logsLength; ++i) {
-            if (entries[i].topics[0] == CCIPSendRequested.selector) {
-                InternalPreV1dot6.EVM2EVMMessage memory message =
-                    abi.decode(entries[i].data, (InternalPreV1dot6.EVM2EVMMessage));
-                if (!s_processedMessages[message.messageId]) {
-                    s_processedMessages[message.messageId] = true;
-                    vm.selectFork(forkId);
-
-                    for (uint256 j = offRampsLength; j > 0; --j) {
-                        if (offRamps[j - 1].sourceChainSelector == message.sourceChainSelector) {
-                            vm.startPrank(offRamps[j - 1].offRamp);
-                            uint256 numberOfTokens = message.tokenAmounts.length;
-                            bytes[] memory offchainTokenData = new bytes[](numberOfTokens);
-                            uint32[] memory tokenGasOverrides = new uint32[](numberOfTokens);
-                            for (uint256 k; k < numberOfTokens; ++k) {
-                                tokenGasOverrides[k] = uint32(message.gasLimit);
-                            }
-                            IEVM2EVMOffRampPreV1dot6Fork(offRamps[j - 1].offRamp).executeSingleMessage(
-                                message, offchainTokenData, tokenGasOverrides
-                            );
-                            vm.stopPrank();
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    function _routePostV1dot6Message(uint256 forkId) internal {
-        uint256 currentForkId = vm.activeFork();
-
-        vm.selectFork(forkId);
-        assertEq(vm.activeFork(), forkId);
-
-        IRouterFork.OffRamp[] memory offRamps =
-            IRouterFork(i_register.getNetworkDetails(block.chainid).routerAddress).getOffRamps();
-        uint256 offRampsLength = offRamps.length;
-
-        vm.selectFork(currentForkId);
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 logsLength = entries.length;
-        for (uint256 i; i < logsLength; ++i) {
-            console2.logBytes32(entries[i].topics[0]);
-            if (entries[i].topics[0] == CCIPMessageSent.selector) {
-                Internal.EVM2AnyRampMessage memory message = abi.decode(entries[i].data, (Internal.EVM2AnyRampMessage));
-                if (!s_processedMessages[message.header.messageId]) {
-                    s_processedMessages[message.header.messageId] = true;
-
-                    for (uint256 j = offRampsLength; j > 0; --j) {
-                        if (offRamps[j - 1].sourceChainSelector == message.header.sourceChainSelector) {
-                            vm.startPrank(offRamps[j - 1].offRamp);
-                            uint256 gasLimit = _fromBytes(message.extraArgs).gasLimit;
-                            uint256 numberOfTokens = message.tokenAmounts.length;
-                            Internal.Any2EVMTokenTransfer[] memory tokenAmounts =
-                                new Internal.Any2EVMTokenTransfer[](numberOfTokens);
-                            for (uint256 k; k < numberOfTokens; ++k) {
-                                tokenAmounts[k] = Internal.Any2EVMTokenTransfer({
-                                    sourcePoolAddress: abi.encodePacked(message.tokenAmounts[k].sourcePoolAddress),
-                                    destTokenAddress: address(uint160(bytes20(message.tokenAmounts[k].destTokenAddress))),
-                                    destGasAmount: abi.decode(message.tokenAmounts[k].destExecData, (uint32)),
-                                    extraData: message.tokenAmounts[k].extraData,
-                                    amount: message.tokenAmounts[k].amount
-                                });
-                            }
-                            Internal.Any2EVMRampMessage memory any2EVMRampMessage = Internal.Any2EVMRampMessage({
-                                header: message.header,
-                                sender: abi.encodePacked(message.sender),
-                                data: message.data,
-                                receiver: address(uint160(bytes20(message.receiver))),
-                                gasLimit: gasLimit,
-                                tokenAmounts: tokenAmounts
-                            });
-                            bytes[] memory offchainTokenData = new bytes[](numberOfTokens);
-                            uint32[] memory tokenGasOverrides = new uint32[](numberOfTokens);
-                            for (uint256 k; k < numberOfTokens; ++k) {
-                                tokenGasOverrides[k] = uint32(gasLimit);
-                            }
-                            IEVM2EVMOffRampFork(offRamps[j - 1].offRamp).executeSingleMessage(
-                                any2EVMRampMessage, offchainTokenData, tokenGasOverrides
-                            );
-                            vm.stopPrank();
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    function _routePostV1dot6Message(uint256 forkId) internal {
-        Internal.EVM2AnyRampMessage memory message;
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 length = entries.length;
-        for (uint256 i; i < length; ++i) {
-            console2.logBytes32(entries[i].topics[0]);
-            if (entries[i].topics[0] == CCIPMessageSent.selector) {
-                message = abi.decode(entries[i].data, (Internal.EVM2AnyRampMessage));
-                if (!s_processedMessages[message.header.messageId]) {
-                    s_processedMessages[message.header.messageId] = true;
-                    break;
-                }
-            }
-        }
-
-        vm.selectFork(forkId);
-        assertEq(vm.activeFork(), forkId);
-
-        IRouterFork.OffRamp[] memory offRamps =
-            IRouterFork(i_register.getNetworkDetails(block.chainid).routerAddress).getOffRamps();
-        length = offRamps.length;
-
-        for (uint256 i = length; i > 0; --i) {
-            if (offRamps[i - 1].sourceChainSelector == message.header.sourceChainSelector) {
-                vm.startPrank(offRamps[i - 1].offRamp);
-                uint256 gasLimit = _fromBytes(message.extraArgs).gasLimit;
-                uint256 numberOfTokens = message.tokenAmounts.length;
-                Internal.Any2EVMTokenTransfer[] memory tokenAmounts =
-                    new Internal.Any2EVMTokenTransfer[](numberOfTokens);
-                for (uint256 j; j < numberOfTokens; ++j) {
-                    tokenAmounts[j] = Internal.Any2EVMTokenTransfer({
-                        sourcePoolAddress: abi.encodePacked(message.tokenAmounts[j].sourcePoolAddress),
-                        destTokenAddress: address(uint160(bytes20(message.tokenAmounts[j].destTokenAddress))),
-                        destGasAmount: abi.decode(message.tokenAmounts[j].destExecData, (uint32)),
-                        extraData: message.tokenAmounts[j].extraData,
-                        amount: message.tokenAmounts[j].amount
-                    });
-                }
-                Internal.Any2EVMRampMessage memory any2EVMRampMessage = Internal.Any2EVMRampMessage({
-                    header: message.header,
-                    sender: abi.encodePacked(message.sender),
-                    data: message.data,
-                    receiver: address(uint160(bytes20(message.receiver))),
-                    gasLimit: gasLimit,
-                    tokenAmounts: tokenAmounts
-                });
-                bytes[] memory offchainTokenData = new bytes[](numberOfTokens);
-                uint32[] memory tokenGasOverrides = new uint32[](numberOfTokens);
-                for (uint256 j; j < numberOfTokens; ++j) {
-                    tokenGasOverrides[j] = uint32(gasLimit);
-                }
-                IEVM2EVMOffRampFork(offRamps[i - 1].offRamp).executeSingleMessage(
-                    any2EVMRampMessage, offchainTokenData, tokenGasOverrides
-                );
-                vm.stopPrank();
-                break;
-            }
-        }
+        _routeCapturedMessages(forkIds, sourceForkId, sourceRouterAddress);
     }
 
     /**
@@ -344,6 +194,148 @@ contract CCIPLocalSimulatorFork is Test {
         vm.stopPrank();
     }
 
+    /**
+     * @notice Internal function to route captured messages to their respective destination forks.
+     *
+     * @param forkIds - The IDs of the destination network forks. These are the returned values of `createFork()` or `createSelectFork()`, not chainIds.
+     * @param sourceForkId - The ID of the source network fork. This is the returned value of `createFork()` or `createSelectFork()`, not chainId.
+     * @param sourceRouterAddress - The address of the Router on the source chain.
+     */
+    function _routeCapturedMessages(uint256[] memory forkIds, uint256 sourceForkId, address sourceRouterAddress)
+        internal
+    {
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 logsLength = entries.length;
+
+        for (uint256 i; i < logsLength; ++i) {
+            // Try Routing pre v1.6 message
+            if (entries[i].topics[0] == CCIPSendRequested.selector) {
+                InternalPreV1dot6.EVM2EVMMessage memory message =
+                    abi.decode(entries[i].data, (InternalPreV1dot6.EVM2EVMMessage));
+
+                if (!s_processedMessages[message.messageId]) {
+                    for (uint256 j; j < forkIds.length; ++j) {
+                        vm.selectFork(forkIds[j]);
+                        uint64 destinationChainSelector = i_register.getNetworkDetails(block.chainid).chainSelector;
+
+                        vm.selectFork(sourceForkId);
+                        address onRampContract = IRouterFork(sourceRouterAddress).getOnRamp(destinationChainSelector);
+
+                        // Deliver message
+                        if (entries[i].emitter == onRampContract) {
+                            vm.selectFork(forkIds[j]);
+
+                            IRouterFork.OffRamp[] memory offRamps =
+                                IRouterFork(i_register.getNetworkDetails(block.chainid).routerAddress).getOffRamps();
+                            uint256 offRampsLength = offRamps.length;
+
+                            for (uint256 k = offRampsLength; k > 0; --k) {
+                                if (offRamps[k - 1].sourceChainSelector == message.sourceChainSelector) {
+                                    vm.startPrank(offRamps[k - 1].offRamp);
+                                    uint256 numberOfTokens = message.tokenAmounts.length;
+                                    bytes[] memory offchainTokenData = new bytes[](numberOfTokens);
+                                    uint32[] memory tokenGasOverrides = new uint32[](numberOfTokens);
+                                    for (uint256 l; l < numberOfTokens; ++l) {
+                                        tokenGasOverrides[l] = uint32(message.gasLimit);
+                                    }
+                                    try IEVM2EVMOffRampPreV1dot6Fork(offRamps[k - 1].offRamp).executeSingleMessage(
+                                        message, offchainTokenData, tokenGasOverrides
+                                    ) {
+                                        vm.stopPrank();
+                                        s_processedMessages[message.messageId] = true;
+                                    } catch (bytes memory err) {
+                                        vm.stopPrank();
+                                        // Solidity does not support yet catching custom errors, so this is the best we can do for now
+                                        console2.logBytes(err);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Try Routing post v1.6 message
+            if (entries[i].topics[0] == CCIPMessageSent.selector) {
+                Internal.EVM2AnyRampMessage memory message = abi.decode(entries[i].data, (Internal.EVM2AnyRampMessage));
+
+                if (!s_processedMessages[message.header.messageId]) {
+                    s_processedMessages[message.header.messageId] = true;
+
+                    for (uint256 j; j < forkIds.length; ++j) {
+                        vm.selectFork(forkIds[j]);
+                        uint64 destinationChainSelector = i_register.getNetworkDetails(block.chainid).chainSelector;
+
+                        vm.selectFork(sourceForkId);
+                        address onRampContract = IRouterFork(sourceRouterAddress).getOnRamp(destinationChainSelector);
+
+                        // Deliver message
+                        if (entries[i].emitter == onRampContract) {
+                            vm.selectFork(forkIds[j]);
+
+                            IRouterFork.OffRamp[] memory offRamps =
+                                IRouterFork(i_register.getNetworkDetails(block.chainid).routerAddress).getOffRamps();
+                            uint256 offRampsLength = offRamps.length;
+
+                            for (uint256 k = offRampsLength; k > 0; --k) {
+                                if (offRamps[k - 1].sourceChainSelector == message.header.sourceChainSelector) {
+                                    vm.startPrank(offRamps[k - 1].offRamp);
+                                    uint256 gasLimit = _fromBytes(message.extraArgs).gasLimit;
+                                    uint256 numberOfTokens = message.tokenAmounts.length;
+                                    Internal.Any2EVMTokenTransfer[] memory tokenAmounts =
+                                        new Internal.Any2EVMTokenTransfer[](numberOfTokens);
+                                    for (uint256 l; l < numberOfTokens; ++l) {
+                                        tokenAmounts[l] = Internal.Any2EVMTokenTransfer({
+                                            sourcePoolAddress: abi.encodePacked(message.tokenAmounts[l].sourcePoolAddress),
+                                            destTokenAddress: address(
+                                                uint160(bytes20(message.tokenAmounts[l].destTokenAddress))
+                                            ),
+                                            destGasAmount: abi.decode(message.tokenAmounts[l].destExecData, (uint32)),
+                                            extraData: message.tokenAmounts[l].extraData,
+                                            amount: message.tokenAmounts[l].amount
+                                        });
+                                    }
+                                    Internal.Any2EVMRampMessage memory any2EVMRampMessage = Internal.Any2EVMRampMessage({
+                                        header: message.header,
+                                        sender: abi.encodePacked(message.sender),
+                                        data: message.data,
+                                        receiver: address(uint160(bytes20(message.receiver))),
+                                        gasLimit: gasLimit,
+                                        tokenAmounts: tokenAmounts
+                                    });
+                                    bytes[] memory offchainTokenData = new bytes[](numberOfTokens);
+                                    uint32[] memory tokenGasOverrides = new uint32[](numberOfTokens);
+                                    for (uint256 l; l < numberOfTokens; ++l) {
+                                        tokenGasOverrides[l] = uint32(gasLimit);
+                                    }
+                                    try IEVM2EVMOffRampFork(offRamps[j - 1].offRamp).executeSingleMessage(
+                                        any2EVMRampMessage, offchainTokenData, tokenGasOverrides
+                                    ) {
+                                        vm.stopPrank();
+                                    } catch (bytes memory err) {
+                                        vm.stopPrank();
+                                        // Solidity does not support yet catching custom errors, so this is the best we can do for now
+                                        console2.logBytes(err);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @notice Internal helper function to decode extraArgs bytes to GenericExtraArgsV2 struct.
+     *         Supports decoding of both GenericExtraArgsV2 and EVMExtraArgsV1 structs.
+     *
+     * @param extraArgs - The bytes representing the extra arguments.
+     *
+     * @return genericExtraArgs - The decoded GenericExtraArgsV2 struct.
+     */
     function _fromBytes(bytes memory extraArgs) internal pure returns (Client.GenericExtraArgsV2 memory) {
         if (extraArgs.length == 0) {
             return Client.GenericExtraArgsV2({gasLimit: DEFAULT_GAS_LIMIT, allowOutOfOrderExecution: false});

--- a/src/ccip/CCIPLocalSimulatorFork.sol
+++ b/src/ccip/CCIPLocalSimulatorFork.sol
@@ -309,7 +309,7 @@ contract CCIPLocalSimulatorFork is Test {
                                     for (uint256 l; l < numberOfTokens; ++l) {
                                         tokenGasOverrides[l] = uint32(gasLimit);
                                     }
-                                    try IEVM2EVMOffRampFork(offRamps[j - 1].offRamp).executeSingleMessage(
+                                    try IEVM2EVMOffRampFork(offRamps[k - 1].offRamp).executeSingleMessage(
                                         any2EVMRampMessage, offchainTokenData, tokenGasOverrides
                                     ) {
                                         vm.stopPrank();

--- a/test/e2e/ccip/LooperFork.t.sol
+++ b/test/e2e/ccip/LooperFork.t.sol
@@ -20,7 +20,7 @@ contract Looper is CCIPReceiver {
         i_link = link;
     }
 
-    function send(address to, uint64 destinationChainSelector, uint256 numberOfMessages) public {
+    function sendNMessages(address to, uint64 destinationChainSelector, uint256 numberOfMessages) public {
         Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
             receiver: abi.encode(to),
             data: abi.encode("Hello, World!"),
@@ -36,6 +36,46 @@ contract Looper is CCIPReceiver {
         }
     }
 
+    function send(address destinationArb, address destinationOp, uint64 chainSelectorArb, uint64 chainSelectorOp)
+        public
+    {
+        Client.EVM2AnyMessage memory messageA = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationArb),
+            data: abi.encode("Hello, World!"),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: "",
+            feeToken: i_link
+        });
+
+        Client.EVM2AnyMessage memory messageB = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationOp),
+            data: abi.encode("Hello, World!"),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: "",
+            feeToken: i_link
+        });
+
+        Client.EVM2AnyMessage memory messageC = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationArb),
+            data: abi.encode("Hello, World!"),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: "",
+            feeToken: i_link
+        });
+
+        uint256 feeA = IRouterClient(i_router).getFee(chainSelectorArb, messageA);
+        IERC20(i_link).approve(address(i_router), feeA);
+        IRouterClient(i_router).ccipSend(chainSelectorArb, messageA);
+
+        uint256 feeB = IRouterClient(i_router).getFee(chainSelectorOp, messageB);
+        IERC20(i_link).approve(address(i_router), feeB);
+        IRouterClient(i_router).ccipSend(chainSelectorOp, messageB);
+
+        uint256 feeC = IRouterClient(i_router).getFee(chainSelectorArb, messageC);
+        IERC20(i_link).approve(address(i_router), feeC);
+        IRouterClient(i_router).ccipSend(chainSelectorArb, messageC);
+    }
+
     function _ccipReceive(Client.Any2EVMMessage memory /*message*/ ) internal override {
         s_messagesReceived++;
     }
@@ -44,41 +84,75 @@ contract Looper is CCIPReceiver {
 contract LooperFork is Test {
     CCIPLocalSimulatorFork public ccipLocalSimulatorFork;
     Looper source;
-    Looper destination;
+    Looper destinationArb;
+    Looper destinationOp;
 
     Register.NetworkDetails sepoliaNetworkDetails;
     Register.NetworkDetails arbSepoliaNetworkDetails;
+    Register.NetworkDetails optimismSepoliaNetworkDetails;
 
     uint256 sepoliaFork;
     uint256 arbSepoliaFork;
+    uint256 optimismSepoliaFork;
 
     function setUp() public {
         string memory ETHEREUM_SEPOLIA_RPC_URL = vm.envString("ETHEREUM_SEPOLIA_RPC_URL");
         string memory ARBITRUM_SEPOLIA_RPC_URL = vm.envString("ARBITRUM_SEPOLIA_RPC_URL");
+        string memory OPTIMISM_SEPOLIA_RPC_URL = vm.envString("OPTIMISM_SEPOLIA_RPC_URL");
         sepoliaFork = vm.createSelectFork(ETHEREUM_SEPOLIA_RPC_URL);
         arbSepoliaFork = vm.createFork(ARBITRUM_SEPOLIA_RPC_URL);
+        optimismSepoliaFork = vm.createFork(OPTIMISM_SEPOLIA_RPC_URL);
 
         ccipLocalSimulatorFork = new CCIPLocalSimulatorFork();
         vm.makePersistent(address(ccipLocalSimulatorFork));
         sepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
 
         source = new Looper(sepoliaNetworkDetails.routerAddress, sepoliaNetworkDetails.linkAddress);
-
         ccipLocalSimulatorFork.requestLinkFromFaucet(address(source), 10 ether);
 
         vm.selectFork(arbSepoliaFork);
         arbSepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
+        destinationArb = new Looper(arbSepoliaNetworkDetails.routerAddress, arbSepoliaNetworkDetails.linkAddress);
 
-        destination = new Looper(arbSepoliaNetworkDetails.routerAddress, arbSepoliaNetworkDetails.linkAddress);
+        vm.selectFork(optimismSepoliaFork);
+        optimismSepoliaNetworkDetails = ccipLocalSimulatorFork.getNetworkDetails(block.chainid);
+        destinationOp =
+            new Looper(optimismSepoliaNetworkDetails.routerAddress, optimismSepoliaNetworkDetails.linkAddress);
     }
 
-    function test_ForkLooper() public {
+    function test_sendNMessagesToSingleChain() public {
         vm.selectFork(sepoliaFork);
-        uint256 numberOfMessages = 3;
 
-        source.send(address(destination), arbSepoliaNetworkDetails.chainSelector, numberOfMessages);
+        uint256 numberOfMessagesToSend = 3;
+        source.sendNMessages(address(destinationArb), arbSepoliaNetworkDetails.chainSelector, numberOfMessagesToSend);
+
         ccipLocalSimulatorFork.switchChainAndRouteMessage(arbSepoliaFork);
+        vm.selectFork(arbSepoliaFork);
+        uint256 numberOfMessagesReceived = destinationArb.s_messagesReceived();
+        assertEq(numberOfMessagesReceived, numberOfMessagesToSend);
+    }
 
-        assertEq(destination.s_messagesReceived(), numberOfMessages);
+    function test_sendNMessagesToMultipleChains() public {
+        vm.selectFork(sepoliaFork);
+
+        source.send(
+            address(destinationArb),
+            address(destinationOp),
+            arbSepoliaNetworkDetails.chainSelector,
+            optimismSepoliaNetworkDetails.chainSelector
+        );
+
+        uint256[] memory forks = new uint256[](2);
+        forks[0] = arbSepoliaFork;
+        forks[1] = optimismSepoliaFork;
+        ccipLocalSimulatorFork.switchChainAndRouteMessage(forks);
+
+        vm.selectFork(arbSepoliaFork);
+        uint256 numberOfMessagesReceived = destinationArb.s_messagesReceived();
+        assertEq(numberOfMessagesReceived, 2);
+
+        vm.selectFork(optimismSepoliaFork);
+        numberOfMessagesReceived = destinationOp.s_messagesReceived();
+        assertEq(numberOfMessagesReceived, 1);
     }
 }


### PR DESCRIPTION
This PR refactors `CCIPLocalSimulatorFork.sol` to deliver more than one message to more than one chain in a same call.