### PR TITLE
Correct v1.6 destTokenAddress and sourcePoolAddress encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9-beta.0] - 7 May 2026
+
+### Dependencies
+
+| Package                   | Version |
+| ------------------------- | ------- |
+| @chainlink/contracts-ccip | 1.6.2   |
+| @chainlink/contracts      | 1.5.0   |
+
+### Fixed
+
+- `CCIPLocalSimulatorFork.switchChainAndRouteMessage` now correctly decodes `destTokenAddress` for v1.6 token transfers. The 32-byte `abi.encode(address)` value was previously truncated via a `bytes20` cast, yielding a garbage address and causing the destination OffRamp's `TokenAdminRegistry.getPool` lookup to revert. Decoding now handles both 32-byte ABI-encoded and 20-byte packed forms, matching production OffRamp behavior, and is shared with `receiver` decoding via a single internal `_decodeEVMAddress` helper.
+- For v1.6 token transfers, `sourcePoolAddress` is now passed to `Internal.Any2EVMTokenTransfer` as `abi.encode(address)` (32-byte word), matching production OnRamp output and destination pool validation. The simulator previously used `abi.encodePacked(address)` (20 bytes), which caused compatible pools to revert with `InvalidSourcePoolAddress` during fork testing.
+
 ## [0.2.9-beta] - 6 May 2026
 
 ### Dependencies
@@ -651,3 +665,4 @@ and this project adheres to
 [0.2.8-beta]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.8-beta
 [0.2.8]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.8
 [0.2.9-beta]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.9-beta
+[0.2.9-beta.0]: https://github.com/smartcontractkit/chainlink-local/releases/tag/v0.2.9-beta.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/local",
-  "version": "0.2.9-beta",
+  "version": "0.2.9-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/local",
-      "version": "0.2.9-beta",
+      "version": "0.2.9-beta.0",
       "license": "MIT",
       "dependencies": {
         "@chainlink/contracts": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@chainlink/local",
   "description": "Chainlink Local Simulator",
   "license": "MIT",
-  "version": "0.2.9-beta",
+  "version": "0.2.9-beta.0",
   "files": [
     "src/**/*.sol",
     "!src/test/**/*",

--- a/src/ccip/CCIPLocalSimulatorFork.sol
+++ b/src/ccip/CCIPLocalSimulatorFork.sol
@@ -120,7 +120,7 @@ contract CCIPLocalSimulatorFork is Test {
 
     error InvalidExtraArgsTag();
 
-    error InvalidReceiverEncoding();
+    error InvalidEVMAddressEncoding(bytes encodedAddress);
 
     uint32 public constant DEFAULT_GAS_LIMIT = 200_000;
 
@@ -406,8 +406,8 @@ contract CCIPLocalSimulatorFork is Test {
         Internal.Any2EVMTokenTransfer[] memory tokenAmounts = new Internal.Any2EVMTokenTransfer[](numberOfTokens);
         for (uint256 l; l < numberOfTokens; ++l) {
             tokenAmounts[l] = Internal.Any2EVMTokenTransfer({
-                sourcePoolAddress: abi.encodePacked(message.tokenAmounts[l].sourcePoolAddress),
-                destTokenAddress: address(uint160(bytes20(message.tokenAmounts[l].destTokenAddress))),
+                sourcePoolAddress: abi.encode(message.tokenAmounts[l].sourcePoolAddress),
+                destTokenAddress: _decodeEVMAddress(message.tokenAmounts[l].destTokenAddress),
                 destGasAmount: abi.decode(message.tokenAmounts[l].destExecData, (uint32)),
                 extraData: message.tokenAmounts[l].extraData,
                 amount: message.tokenAmounts[l].amount
@@ -417,7 +417,7 @@ contract CCIPLocalSimulatorFork is Test {
             header: message.header,
             sender: abi.encodePacked(message.sender),
             data: message.data,
-            receiver: _decodeEvmReceiverAddress(message.receiver),
+            receiver: _decodeEVMAddress(message.receiver),
             gasLimit: gasLimit,
             tokenAmounts: tokenAmounts
         });
@@ -440,17 +440,18 @@ contract CCIPLocalSimulatorFork is Test {
     }
 
     /**
-     * @notice Decodes `Client.EVM2AnyMessage.receiver` bytes to an EVM address.
-     * @dev CCIP uses `abi.encode(address)` (32 bytes). A legacy 20-byte encoding is also supported.
+     * @notice Decodes ABI-encoded EVM address bytes to an `address`.
+     * @dev Used for `Client.EVM2AnyMessage.receiver` and `Internal.EVM2AnyTokenTransfer.destTokenAddress`.
+     *      CCIP uses `abi.encode(address)` (32 bytes). A legacy 20-byte packed encoding is also supported.
      */
-    function _decodeEvmReceiverAddress(bytes memory encodedReceiver) internal pure returns (address) {
-        if (encodedReceiver.length == 32) {
-            return abi.decode(encodedReceiver, (address));
+    function _decodeEVMAddress(bytes memory encodedAddress) internal pure returns (address) {
+        if (encodedAddress.length == 32) {
+            return abi.decode(encodedAddress, (address));
         }
-        if (encodedReceiver.length == 20) {
-            return address(uint160(bytes20(encodedReceiver)));
+        if (encodedAddress.length == 20) {
+            return address(uint160(bytes20(encodedAddress)));
         }
-        revert InvalidReceiverEncoding();
+        revert InvalidEVMAddressEncoding(encodedAddress);
     }
 
     /**

--- a/test/e2e/ccip/EthSepoliaToArbSepoliaMultiOffRampFork.t.sol
+++ b/test/e2e/ccip/EthSepoliaToArbSepoliaMultiOffRampFork.t.sol
@@ -6,6 +6,7 @@ import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 import {IRouterClient} from "@chainlink/contracts-ccip/contracts/interfaces/IRouterClient.sol";
 import {CCIPReceiver} from "@chainlink/contracts-ccip/contracts/applications/CCIPReceiver.sol";
 import {IERC20} from "../../../src/vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {BurnMintERC677Helper} from "@chainlink/local/src/ccip/CCIPLocalSimulator.sol";
 import {CCIPLocalSimulatorFork, IRouterFork} from "../../../src/ccip/CCIPLocalSimulatorFork.sol";
 import {Register} from "../../../src/ccip/Register.sol";
 
@@ -96,5 +97,38 @@ contract EthSepoliaToArbSepoliaMultiOffRampForkTest is Test {
 
         vm.selectFork(arbSepoliaFork);
         assertEq(receiver.lastPayload(), payload);
+    }
+
+    /// @notice Regression: v1.6 token transfers must decode `destTokenAddress` as ABI-encoded address (32 bytes), not via `bytes20` truncation 
+    function test_transferBnMFromRouter_payFeesInNative_multiOffRampLane() public {
+        address recipientAddr = makeAddr("recipient");
+
+        vm.selectFork(sepoliaFork);
+
+        uint256 amountToSend = 100;
+        BurnMintERC677Helper ccipBnMSource = BurnMintERC677Helper(sepoliaDetails.ccipBnMAddress);
+        ccipBnMSource.drip(address(this));
+        IERC20(sepoliaDetails.ccipBnMAddress).approve(address(sepoliaRouter), amountToSend);
+
+        Client.EVMTokenAmount[] memory tokensToSendDetails = new Client.EVMTokenAmount[](1);
+        tokensToSendDetails[0] =
+            Client.EVMTokenAmount({token: sepoliaDetails.ccipBnMAddress, amount: amountToSend});
+
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(recipientAddr),
+            data: abi.encode(""),
+            tokenAmounts: tokensToSendDetails,
+            extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: 0})),
+            feeToken: address(0)
+        });
+
+        uint256 fees = sepoliaRouter.getFee(arbDetails.chainSelector, message);
+        vm.deal(address(this), fees + 1);
+        sepoliaRouter.ccipSend{value: fees}(arbDetails.chainSelector, message);
+
+        ccipFork.switchChainAndRouteMessage(arbSepoliaFork);
+
+        vm.selectFork(arbSepoliaFork);
+        assertEq(IERC20(arbDetails.ccipBnMAddress).balanceOf(recipientAddr), amountToSend);
     }
 }

--- a/test/unit/ccip/CCIPLocalSimulatorForkRouting.t.sol
+++ b/test/unit/ccip/CCIPLocalSimulatorForkRouting.t.sol
@@ -12,7 +12,7 @@ import {
 /// @dev Exposes internal OffRamp resolution for unit testing.
 contract CCIPLocalSimulatorForkHarness is CCIPLocalSimulatorFork {
     function exposedDecodeReceiver(bytes memory encoded) external pure returns (address) {
-        return _decodeEvmReceiverAddress(encoded);
+        return _decodeEVMAddress(encoded);
     }
 
     function exposedFindOffRamp(


### PR DESCRIPTION
This PR fixes address encoding/decoding issues in the CCIPSimulatorFork (20/32 bytes between different CCIP versions)